### PR TITLE
Convert README to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ with the language.
 
 Use is fairly simple:
 
+```python
 import sys
 from dynect.DynectDNS import DynectRest
 
@@ -62,6 +63,6 @@ zone_resources = response['data']
 
 # Log out, to be polite
 rest_iface.execute('/Session/', 'DELETE')
+```
 
-Documentation on the REST resources can be found at 
-https://manage.dynect.net/help/docs/api2/rest/resources/
+Documentation on the REST resources can be found on the [DynECT Help site](https://help.dynect.net/dns-api-knowledge-base/)


### PR DESCRIPTION
Converting the plaintext README to the markdown version. Also updating the documentation link.

This cleans things up a bit.  More could be done, but this was just bugging me.
