### PR TITLE
using relative import to fix and issue with Python 3.4

### DIFF
--- a/dynect/__init__.py
+++ b/dynect/__init__.py
@@ -2,4 +2,4 @@
 version = '0.1'
 version_info = (0, 1)
 
-from DynectDNS import DynectRest
+from .DynectDNS import DynectRest


### PR DESCRIPTION
This fixes an importing problem with Python 3.4 as detailed in issue #11 

Tested on both Python 2.7 and Python 3.4